### PR TITLE
fix(dv360): upgrade API to v4 and add CAMPAIGN entity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ Given the above JSON source we could add the following to our Sheet:
 
 ### DV360
 
+**Supported Target Identifier Types (`target:type`)**
+
+- `CAMPAIGN`
+- `INSERTION_ORDER`
+- `LINE_ITEM`
+
 **Required parameters**
 
 - `target:advertiserId`

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,6 +327,7 @@ var DV360_ENTITY_TYPE;
 (function (DV360_ENTITY_TYPE) {
     DV360_ENTITY_TYPE["LINE_ITEM"] = "LINE_ITEM";
     DV360_ENTITY_TYPE["INSERTION_ORDER"] = "INSERTION_ORDER";
+    DV360_ENTITY_TYPE["CAMPAIGN"] = "CAMPAIGN";
 })(DV360_ENTITY_TYPE || (DV360_ENTITY_TYPE = {}));
 var DV360_ACTION;
 (function (DV360_ACTION) {
@@ -336,7 +337,7 @@ class DV360 extends TargetAgent {
     constructor() {
         super();
         this.requiredParameters = ['advertiserId'];
-        this.baseUrl = 'https://displayvideo.googleapis.com/v2';
+        this.baseUrl = 'https://displayvideo.googleapis.com/v4';
     }
     process(identifier, type, action, evaluation, params) {
         this.ensureRequiredParameters(params);
@@ -356,6 +357,9 @@ class DV360 extends TargetAgent {
         else if (type === DV360_ENTITY_TYPE.INSERTION_ORDER) {
             this.setInsertionOrderStatus(params.advertiserId, identifier, evaluation);
         }
+        else if (type === DV360_ENTITY_TYPE.CAMPAIGN) {
+            this.setCampaignStatus(params.advertiserId, identifier, evaluation);
+        }
     }
     validate(identifier, type, action, evaluation, params) {
         this.ensureRequiredParameters(params);
@@ -368,6 +372,9 @@ class DV360 extends TargetAgent {
         }
         else if (type === DV360_ENTITY_TYPE.INSERTION_ORDER) {
             status = this.isInsertionOrderActive(params.advertiserId, identifier);
+        }
+        else if (type === DV360_ENTITY_TYPE.CAMPAIGN) {
+            status = this.isCampaignActive(params.advertiserId, identifier);
         }
         if (evaluation !== status) {
             errors.push(`Status for ${identifier} (${type}) should be ${evaluation} but is ${status}`);
@@ -398,6 +405,9 @@ class DV360 extends TargetAgent {
     setInsertionOrderStatus(advertiserId, insertionOrderId, status) {
         this.setEntityStatus(advertiserId, insertionOrderId, status, 'insertionOrders');
     }
+    setCampaignStatus(advertiserId, campaignId, status) {
+        this.setEntityStatus(advertiserId, campaignId, status, 'campaigns');
+    }
     getEntity(advertiserId, entityId, entity) {
         const url = `${this.baseUrl}/advertisers/${advertiserId}/${entity}/${entityId}`;
         return this.fetchUrl(url);
@@ -408,6 +418,10 @@ class DV360 extends TargetAgent {
     }
     isInsertionOrderActive(advertiserId, insertionOrderId) {
         const entity = this.getEntity(advertiserId, insertionOrderId, 'insertionOrders');
+        return DV360_ENTITY_STATUS.ACTIVE === entity.entityStatus;
+    }
+    isCampaignActive(advertiserId, campaignId) {
+        const entity = this.getEntity(advertiserId, campaignId, 'campaigns');
         return DV360_ENTITY_STATUS.ACTIVE === entity.entityStatus;
     }
 }

--- a/src/target-agents/dv360.ts
+++ b/src/target-agents/dv360.ts
@@ -25,6 +25,7 @@ export enum DV360_ENTITY_STATUS {
 export enum DV360_ENTITY_TYPE {
   LINE_ITEM = 'LINE_ITEM',
   INSERTION_ORDER = 'INSERTION_ORDER',
+  CAMPAIGN = 'CAMPAIGN',
 }
 
 export enum DV360_ACTION {
@@ -58,7 +59,7 @@ export class DV360 extends TargetAgent {
     /**
      * DV360 Write API Endpoint Prefix
      */
-    this.baseUrl = 'https://displayvideo.googleapis.com/v2';
+    this.baseUrl = 'https://displayvideo.googleapis.com/v4';
   }
 
   /**
@@ -110,6 +111,8 @@ export class DV360 extends TargetAgent {
       this.setLineItemStatus(params.advertiserId, identifier, evaluation);
     } else if (type === DV360_ENTITY_TYPE.INSERTION_ORDER) {
       this.setInsertionOrderStatus(params.advertiserId, identifier, evaluation);
+    } else if (type === DV360_ENTITY_TYPE.CAMPAIGN) {
+      this.setCampaignStatus(params.advertiserId, identifier, evaluation);
     }
   }
 
@@ -143,6 +146,8 @@ export class DV360 extends TargetAgent {
       status = this.isLineItemActive(params.advertiserId, identifier);
     } else if (type === DV360_ENTITY_TYPE.INSERTION_ORDER) {
       status = this.isInsertionOrderActive(params.advertiserId, identifier);
+    } else if (type === DV360_ENTITY_TYPE.CAMPAIGN) {
+      status = this.isCampaignActive(params.advertiserId, identifier);
     }
 
     if (evaluation !== status) {
@@ -235,6 +240,21 @@ export class DV360 extends TargetAgent {
   }
 
   /**
+   * Change Campaign status (Active/Paused) for the specified Campaign ID.
+   *
+   * @param {string} advertiserId DV360 Advertiser ID
+   * @param {string} campaignId DV360 Campaign ID
+   * @param {boolean} status Activate Campaign on 'true', deactivate on 'false'
+   */
+  private setCampaignStatus(
+    advertiserId: string,
+    campaignId: string,
+    status: boolean
+  ) {
+    this.setEntityStatus(advertiserId, campaignId, status, 'campaigns');
+  }
+
+  /**
    * Get DV360 entity for the specified ID.
    *
    * @param {string} advertiserId DV360 Advertiser ID
@@ -281,6 +301,19 @@ export class DV360 extends TargetAgent {
       insertionOrderId,
       'insertionOrders'
     );
+
+    return DV360_ENTITY_STATUS.ACTIVE === entity.entityStatus;
+  }
+
+  /**
+   * Return true if the entity is active else false.
+   *
+   * @param {string} advertiserId DV360 Advertiser ID
+   * @param {string} campaignId DV360 Campaign ID
+   * @returns {boolean}
+   */
+  private isCampaignActive(advertiserId: string, campaignId: string) {
+    const entity = this.getEntity(advertiserId, campaignId, 'campaigns');
 
     return DV360_ENTITY_STATUS.ACTIVE === entity.entityStatus;
   }

--- a/test/target-agents/dv360.test.ts
+++ b/test/target-agents/dv360.test.ts
@@ -64,6 +64,41 @@ describe('DV360 Target Agent', () => {
         'lineItems'
       );
     });
+
+    it('Updates Campaign correctly', () => {
+      const dv360 = new DV360();
+
+      // Set up spies
+      jest.spyOn(DV360.prototype as any, 'fetchUrl').mockReturnValue(null);
+
+      const setCampaignStatusSpy = jest.spyOn(
+        DV360.prototype as any,
+        'setCampaignStatus'
+      );
+
+      const setEntityStatusSpy = jest.spyOn(
+        DV360.prototype as any,
+        'setEntityStatus'
+      );
+
+      // Call function
+      dv360.process(
+        '1234',
+        DV360_ENTITY_TYPE.CAMPAIGN,
+        DV360_ACTION.TOGGLE,
+        true,
+        params
+      );
+
+      // Evaluate
+      expect(setCampaignStatusSpy).toHaveBeenCalledWith('1', '1234', true);
+      expect(setEntityStatusSpy).toHaveBeenCalledWith(
+        '1',
+        '1234',
+        true,
+        'campaigns'
+      );
+    });
   });
 
   describe('validate', () => {
@@ -96,7 +131,40 @@ describe('DV360 Target Agent', () => {
       expect(isLIActiveSpy).toHaveBeenCalledWith('1', '1234');
       expect(getEntitySpy).toHaveBeenCalledWith('1', '1234', 'lineItems');
       expect(fetchUrlSpy).toHaveBeenCalledWith(
-        'https://displayvideo.googleapis.com/v2/advertisers/1/lineItems/1234'
+        'https://displayvideo.googleapis.com/v4/advertisers/1/lineItems/1234'
+      );
+    });
+
+    it('Validates Campaign status match correctly', () => {
+      const dv360 = new DV360();
+
+      const campaign = {
+        entityStatus: 'ENTITY_STATUS_ACTIVE',
+      };
+
+      // Set up spies
+      jest.spyOn(DV360.prototype as any, 'fetchUrl').mockReturnValue(campaign);
+      const isCampaignActiveSpy = jest.spyOn(
+        DV360.prototype as any,
+        'isCampaignActive'
+      );
+      const getEntitySpy = jest.spyOn(DV360.prototype as any, 'getEntity');
+      const fetchUrlSpy = jest.spyOn(DV360.prototype as any, 'fetchUrl');
+
+      // Call function
+      dv360.validate(
+        '1234',
+        DV360_ENTITY_TYPE.CAMPAIGN,
+        DV360_ACTION.TOGGLE,
+        true,
+        params
+      );
+
+      // Evaluate
+      expect(isCampaignActiveSpy).toHaveBeenCalledWith('1', '1234');
+      expect(getEntitySpy).toHaveBeenCalledWith('1', '1234', 'campaigns');
+      expect(fetchUrlSpy).toHaveBeenCalledWith(
+        'https://displayvideo.googleapis.com/v4/advertisers/1/campaigns/1234'
       );
     });
   });


### PR DESCRIPTION
## Description

This PR introduces two essential improvements to the DV360 Target Agent:

1. **DV360 REST API v4 Upgrade (Bug Fix)**:
   - Upgrades `baseUrl` from deprecated/sunset `v2` to `v4` (`https://displayvideo.googleapis.com/v4`).
   - Resolves `404 Not Found` HTML errors from Google Frontend when making requests to sunset v2 endpoints.

2. **CAMPAIGN Target Identifier Support (Feature)**:
   - Adds `CAMPAIGN` to `DV360_ENTITY_TYPE`.
   - Implements `setCampaignStatus` and `isCampaignActive` helper methods.
   - Allows users to pause/activate entire campaigns hierarchically, saving API calls and enabling workarounds for media formats without direct IO/LI REST API mutation support (e.g. DOOH).

## Changes Made
- `src/target-agents/dv360.ts`: Updated API base URL to `v4`, added `CAMPAIGN` to enum, implemented `setCampaignStatus` and `isCampaignActive`.
- `test/target-agents/dv360.test.ts`: Added unit test coverage for `CAMPAIGN` status updates and validation checks against `v4` endpoints.
- `README.md`: Documented `CAMPAIGN` under supported target identifier types for DV360.
- `dist/index.js`: Compiled build bundle via Rollup.

## Test Plan
- [x] Ran unit test suite via `npm test` (all 20 tests passing).
- [x] Ran `npm run build` to verify clean bundle generation.
- [x] End-to-end verified in live Google Apps Script environment with active DV360 seat.
