### PR TITLE
feat(auth): load service account credentials from Apps Script Script Properties

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -266,8 +266,12 @@ var AUTH_MODE;
 })(AUTH_MODE || (AUTH_MODE = {}));
 class Auth {
     constructor(account) {
-        this.authMode = account ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
-        this.serviceAccount = account;
+        const saProperty = typeof PropertiesService !== 'undefined'
+            ? PropertiesService.getScriptProperties().getProperty('serviceAccount')
+            : null;
+        const sa = account ?? (saProperty ? JSON.parse(saProperty) : undefined);
+        this.authMode = sa ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
+        this.serviceAccount = sa;
     }
     getAuthToken() {
         if (this.authMode === AUTH_MODE.USER) {
@@ -281,10 +285,12 @@ class Auth {
             .setTokenUrl('https://accounts.google.com/o/oauth2/token')
             .setPrivateKey(this.serviceAccount.private_key)
             .setIssuer(this.serviceAccount.client_email)
-            .setSubject(this.serviceAccount.user_email)
             .setPropertyStore(PropertiesService.getScriptProperties())
             .setParam('access_type', 'offline')
             .setScope('https://www.googleapis.com/auth/display-video');
+        if (this.serviceAccount.user_email) {
+            service.setSubject(this.serviceAccount.user_email);
+        }
         service.reset();
         return service.getAccessToken();
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -266,10 +266,18 @@ var AUTH_MODE;
 })(AUTH_MODE || (AUTH_MODE = {}));
 class Auth {
     constructor(account) {
-        const saProperty = typeof PropertiesService !== 'undefined'
-            ? PropertiesService.getScriptProperties().getProperty('serviceAccount')
-            : null;
-        const sa = account ?? (saProperty ? JSON.parse(saProperty) : undefined);
+        let sa = account;
+        if (!sa && typeof PropertiesService !== 'undefined') {
+            const saProperty = PropertiesService.getScriptProperties().getProperty('serviceAccount');
+            if (saProperty) {
+                try {
+                    sa = JSON.parse(saProperty);
+                }
+                catch (e) {
+                    console.warn('Failed to parse serviceAccount from Script Properties:', e);
+                }
+            }
+        }
         this.authMode = sa ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
         this.serviceAccount = sa;
     }

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -25,7 +25,7 @@ export interface ServiceAccount {
   token_uri: 'https://oauth2.googleapis.com/token';
   auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs';
   client_x509_cert_url: string;
-  user_email: string;
+  user_email?: string;
 }
 
 export enum AUTH_MODE {
@@ -68,8 +68,14 @@ export class Auth {
    * @param {?Object} account The service account or empty
    */
   constructor(account?: Object) {
-    this.authMode = account ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
-    this.serviceAccount = account as ServiceAccount;
+    const saProperty =
+      typeof PropertiesService !== 'undefined'
+        ? PropertiesService.getScriptProperties().getProperty('serviceAccount')
+        : null;
+    const sa = account ?? (saProperty ? JSON.parse(saProperty) : undefined);
+
+    this.authMode = sa ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
+    this.serviceAccount = sa as ServiceAccount;
   }
 
   /**
@@ -95,10 +101,13 @@ export class Auth {
       .setTokenUrl('https://accounts.google.com/o/oauth2/token')
       .setPrivateKey(this.serviceAccount.private_key)
       .setIssuer(this.serviceAccount.client_email)
-      .setSubject(this.serviceAccount.user_email)
       .setPropertyStore(PropertiesService.getScriptProperties())
       .setParam('access_type', 'offline')
       .setScope('https://www.googleapis.com/auth/display-video');
+
+    if (this.serviceAccount.user_email) {
+      service.setSubject(this.serviceAccount.user_email);
+    }
 
     service.reset();
     return service.getAccessToken();

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -68,11 +68,22 @@ export class Auth {
    * @param {?Object} account The service account or empty
    */
   constructor(account?: Object) {
-    const saProperty =
-      typeof PropertiesService !== 'undefined'
-        ? PropertiesService.getScriptProperties().getProperty('serviceAccount')
-        : null;
-    const sa = account ?? (saProperty ? JSON.parse(saProperty) : undefined);
+    let sa = account;
+
+    if (!sa && typeof PropertiesService !== 'undefined') {
+      const saProperty =
+        PropertiesService.getScriptProperties().getProperty('serviceAccount');
+      if (saProperty) {
+        try {
+          sa = JSON.parse(saProperty);
+        } catch (e) {
+          console.warn(
+            'Failed to parse serviceAccount from Script Properties:',
+            e
+          );
+        }
+      }
+    }
 
     this.authMode = sa ? AUTH_MODE.SERVICE_ACCOUNT : AUTH_MODE.USER;
     this.serviceAccount = sa as ServiceAccount;

--- a/test/helpers/auth.test.ts
+++ b/test/helpers/auth.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Auth, AUTH_MODE, ServiceAccount } from '../../src/helpers/auth';
+
+describe('Auth Helper', () => {
+  const mockServiceAccount: ServiceAccount = {
+    type: 'this.serviceAccount',
+    project_id: 'test-project',
+    private_key_id: 'key-id-123',
+    private_key: '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASC...',
+    client_email: 'test-sa@test-project.iam.gserviceaccount.com',
+    client_id: '123456789',
+    auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+    token_uri: 'https://oauth2.googleapis.com/token',
+    auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+    client_x509_cert_url: 'https://www.googleapis.com/robot/v1/metadata/x509/test-sa',
+  };
+
+  afterEach(() => {
+    delete (global as Record<string, unknown>).PropertiesService;
+    delete (global as Record<string, unknown>).ScriptApp;
+    delete (global as Record<string, unknown>).OAuth2;
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('defaults to USER mode when no account and no PropertiesService', () => {
+      const auth = new Auth();
+
+      expect(auth.authMode).toBe(AUTH_MODE.USER);
+      expect(auth.serviceAccount).toBeUndefined();
+    });
+
+    it('uses provided service account object directly', () => {
+      const auth = new Auth(mockServiceAccount);
+
+      expect(auth.authMode).toBe(AUTH_MODE.SERVICE_ACCOUNT);
+      expect(auth.serviceAccount).toEqual(mockServiceAccount);
+    });
+
+    it('loads service account from Script Properties when account is not provided', () => {
+      const getPropertyMock = jest.fn().mockReturnValue(JSON.stringify(mockServiceAccount));
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: () => ({
+          getProperty: getPropertyMock,
+        }),
+      };
+
+      const auth = new Auth();
+
+      expect(getPropertyMock).toHaveBeenCalledWith('serviceAccount');
+      expect(auth.authMode).toBe(AUTH_MODE.SERVICE_ACCOUNT);
+      expect(auth.serviceAccount).toEqual(mockServiceAccount);
+    });
+
+    it('gracefully handles malformed JSON in Script Properties with console.warn', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const getPropertyMock = jest.fn().mockReturnValue('{"invalid_json:');
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: () => ({
+          getProperty: getPropertyMock,
+        }),
+      };
+
+      const auth = new Auth();
+
+      expect(getPropertyMock).toHaveBeenCalledWith('serviceAccount');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to parse serviceAccount from Script Properties:',
+        expect.any(Error)
+      );
+      expect(auth.authMode).toBe(AUTH_MODE.USER);
+      expect(auth.serviceAccount).toBeUndefined();
+    });
+
+    it('defaults to USER mode when serviceAccount property is null or empty', () => {
+      const getPropertyMock = jest.fn().mockReturnValue(null);
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: () => ({
+          getProperty: getPropertyMock,
+        }),
+      };
+
+      const auth = new Auth();
+
+      expect(getPropertyMock).toHaveBeenCalledWith('serviceAccount');
+      expect(auth.authMode).toBe(AUTH_MODE.USER);
+      expect(auth.serviceAccount).toBeUndefined();
+    });
+
+    it('prefers explicit account over Script Properties', () => {
+      const getPropertyMock = jest.fn();
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: () => ({
+          getProperty: getPropertyMock,
+        }),
+      };
+
+      const customAccount = { ...mockServiceAccount, project_id: 'explicit-project' };
+      const auth = new Auth(customAccount);
+
+      expect(getPropertyMock).not.toHaveBeenCalled();
+      expect(auth.authMode).toBe(AUTH_MODE.SERVICE_ACCOUNT);
+      expect(auth.serviceAccount).toEqual(customAccount);
+    });
+  });
+
+  describe('getAuthToken', () => {
+    it('returns token from ScriptApp in USER mode', () => {
+      (global as Record<string, unknown>).ScriptApp = {
+        getOAuthToken: jest.fn().mockReturnValue('mock-user-token'),
+      };
+
+      const auth = new Auth();
+      const token = auth.getAuthToken();
+
+      expect(token).toBe('mock-user-token');
+      expect(((global as Record<string, unknown>).ScriptApp as { getOAuthToken: jest.Mock }).getOAuthToken).toHaveBeenCalled();
+    });
+
+    it('throws error in SERVICE_ACCOUNT mode if service account is invalid', () => {
+      const invalidAccount = { client_email: 'sa@test.com' };
+      const auth = new Auth(invalidAccount);
+
+      expect(() => auth.getAuthToken()).toThrow('No or invalid service account provided');
+    });
+
+    it('configures OAuth2 service and returns access token without domain-wide delegation', () => {
+      const mockOAuthService = {
+        setTokenUrl: jest.fn().mockReturnThis(),
+        setPrivateKey: jest.fn().mockReturnThis(),
+        setIssuer: jest.fn().mockReturnThis(),
+        setSubject: jest.fn().mockReturnThis(),
+        setPropertyStore: jest.fn().mockReturnThis(),
+        setParam: jest.fn().mockReturnThis(),
+        setScope: jest.fn().mockReturnThis(),
+        reset: jest.fn().mockReturnThis(),
+        getAccessToken: jest.fn().mockReturnValue('mock-sa-token'),
+      };
+
+      (global as Record<string, unknown>).OAuth2 = {
+        createService: jest.fn().mockReturnValue(mockOAuthService),
+      };
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: jest.fn().mockReturnValue('mock-store'),
+      };
+
+      const auth = new Auth(mockServiceAccount);
+      const token = auth.getAuthToken();
+
+      expect(token).toBe('mock-sa-token');
+      expect(((global as Record<string, unknown>).OAuth2 as { createService: jest.Mock }).createService).toHaveBeenCalledWith(
+        'Service Account'
+      );
+      expect(mockOAuthService.setTokenUrl).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/token');
+      expect(mockOAuthService.setPrivateKey).toHaveBeenCalledWith(mockServiceAccount.private_key);
+      expect(mockOAuthService.setIssuer).toHaveBeenCalledWith(mockServiceAccount.client_email);
+      expect(mockOAuthService.setSubject).not.toHaveBeenCalled();
+      expect(mockOAuthService.setScope).toHaveBeenCalledWith('https://www.googleapis.com/auth/display-video');
+      expect(mockOAuthService.reset).toHaveBeenCalled();
+      expect(mockOAuthService.getAccessToken).toHaveBeenCalled();
+    });
+
+    it('calls setSubject when user_email is present in service account', () => {
+      const mockOAuthService = {
+        setTokenUrl: jest.fn().mockReturnThis(),
+        setPrivateKey: jest.fn().mockReturnThis(),
+        setIssuer: jest.fn().mockReturnThis(),
+        setSubject: jest.fn().mockReturnThis(),
+        setPropertyStore: jest.fn().mockReturnThis(),
+        setParam: jest.fn().mockReturnThis(),
+        setScope: jest.fn().mockReturnThis(),
+        reset: jest.fn().mockReturnThis(),
+        getAccessToken: jest.fn().mockReturnValue('mock-delegated-token'),
+      };
+
+      (global as Record<string, unknown>).OAuth2 = {
+        createService: jest.fn().mockReturnValue(mockOAuthService),
+      };
+      (global as Record<string, unknown>).PropertiesService = {
+        getScriptProperties: jest.fn().mockReturnValue('mock-store'),
+      };
+
+      const delegatedAccount: ServiceAccount = {
+        ...mockServiceAccount,
+        user_email: 'delegated-user@example.com',
+      };
+
+      const auth = new Auth(delegatedAccount);
+      const token = auth.getAuthToken();
+
+      expect(token).toBe('mock-delegated-token');
+      expect(mockOAuthService.setSubject).toHaveBeenCalledWith('delegated-user@example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR updates Service Account authentication in IFTTA to follow Google Apps Script best practices ([Authenticate using service accounts](https://developers.google.com/apps-script/guides/service-account#service-credentials-in-apps-script)).

### Problem
Previously, service account credentials could only be passed via spreadsheet row parameters (`target:serviceAccount`). This posed two key issues:
1. **Security Anti-Pattern**: Storing sensitive service account private keys in plaintext inside spreadsheet cells exposes credentials to any user with sheet view access and persists them permanently in version history.
2. **Forced Domain-Wide Delegation**: `Auth.getAuthToken()` unconditionally called `.setSubject(this.serviceAccount.user_email)`. For standard GCP service accounts without Google Workspace domain-wide delegation, Google returns an `unauthorized_client` error.

### Changes
* **Script Properties Auto-Discovery**: If `account` is not passed as an argument to `Auth`, it checks `PropertiesService.getScriptProperties().getProperty('serviceAccount')` and parses the JSON string.
* **Fallback to User OAuth**: If no service account is found in Script Properties or parameters, it seamlessly falls back to standard user OAuth (`ScriptApp.getOAuthToken()`).
* **Conditional Subject Impersonation**: Only calls `.setSubject(this.serviceAccount.user_email)` when `user_email` is explicitly defined, allowing standard GCP service accounts to authenticate directly without domain-wide delegation.
* **Type Definition Update**: Made `user_email?: string` optional in `ServiceAccount` interface to match standard GCP service account JSON structures.

### Verification
* Built project bundle (`dist/index.js`) using Rollup.
* Executed full test suite (`npm test`); all 5 test suites (20 tests) pass.